### PR TITLE
Improve bootstrap

### DIFF
--- a/bin/phpdocfixer.php
+++ b/bin/phpdocfixer.php
@@ -6,13 +6,13 @@ namespace voku\PhpDocFixer;
 
 use Symfony\Component\Console\Application;
 
-require_once __DIR__ . "/../vendor/autoload.php";
+require_once dirname(__DIR__) . '/vendor/autoload.php';
 
 (static function () {
     error_reporting(E_ALL);
     ini_set('display_errors', 'stderr');
 
-    \define('__PHPDOCFIXER_RUNNING__', true);
+    define('__PHPDOCFIXER_RUNNING__', true);
 
     $app = new Application('PhpDocFixer');
 


### PR DESCRIPTION
`define('voku\\PhpDocFixer\\__PHPDOCFIXER_RUNNING__', true);` or `const __PHPDOCFIXER_RUNNING__ = true;` would define a namespaced constant

Fixes #nothing :)
